### PR TITLE
Added method to change the leftPadding (space between snackbar and ...

### DIFF
--- a/Example-Swift/TTGSnackbarExample/ViewController.swift
+++ b/Example-Swift/TTGSnackbarExample/ViewController.swift
@@ -26,6 +26,9 @@ class ViewController: UIViewController {
     @IBAction func show(sender: UIButton) {
         let snackbar: TTGSnackbar = TTGSnackbar.init(message: messageTextField.text!, duration: durationTypes[durationSegmented.selectedSegmentIndex])
         
+        // Change the left padding
+        // snackbar.leftPadding = 15
+        
         // Change message text font and color
         snackbar.messageTextColor = UIColor.yellowColor()
         snackbar.messageTextFont = UIFont.boldSystemFontOfSize(18)

--- a/TTGSnackbar/TTGSnackbar.swift
+++ b/TTGSnackbar/TTGSnackbar.swift
@@ -142,6 +142,14 @@ public class TTGSnackbar: UIView {
             self.layoutIfNeeded()
         }
     }
+    
+    /// Left padding. Default is 2
+    public dynamic var leftPadding: CGFloat = 2 {
+        didSet {
+            leftPaddingConstraint?.constant = leftPadding
+            self.layoutIfNeeded()
+        }
+    }
 
     /// Height: [44, +]. Default is 44
     public dynamic var height: CGFloat = 44 {
@@ -257,6 +265,7 @@ public class TTGSnackbar: UIView {
     private var rightMarginConstraint: NSLayoutConstraint? = nil
     private var bottomMarginConstraint: NSLayoutConstraint? = nil
     private var topMarginConstraint: NSLayoutConstraint? = nil
+    private var leftPaddingConstraint: NSLayoutConstraint? = nil
     private var iconImageViewWidthConstraint: NSLayoutConstraint? = nil
     private var actionButtonWidthConstraint: NSLayoutConstraint? = nil
     private var secondActionButtonWidthConstraint: NSLayoutConstraint? = nil
@@ -611,11 +620,13 @@ private extension TTGSnackbar {
 
         // Add constraints
         let hConstraints: [NSLayoutConstraint] = NSLayoutConstraint.constraintsWithVisualFormat(
-        "H:|-2-[iconImageView]-2-[messageLabel]-2-[seperateView(0.5)]-2-[actionButton]-0-[secondActionButton]-4-|",
+        "H:|-2@500-[iconImageView]-2-[messageLabel]-2-[seperateView(0.5)]-2-[actionButton]-0-[secondActionButton]-4-|",
                 options: NSLayoutFormatOptions(rawValue: 0),
                 metrics: nil,
                 views: ["iconImageView": iconImageView, "messageLabel": messageLabel, "seperateView": seperateView, "actionButton": actionButton, "secondActionButton": secondActionButton])
 
+        leftPaddingConstraint = NSLayoutConstraint.init(item: iconImageView, attribute: .Leading, relatedBy: .Equal, toItem: self, attribute: .Left, multiplier: 1, constant: leftPadding)
+        
         let vConstraintsForIconImageView: [NSLayoutConstraint] = NSLayoutConstraint.constraintsWithVisualFormat(
         "V:|-2-[iconImageView]-2-|",
                 options: NSLayoutFormatOptions(rawValue: 0),
@@ -675,6 +686,7 @@ private extension TTGSnackbar {
         secondActionButton.addConstraint(secondActionButtonWidthConstraint!)
 
         self.addConstraints(hConstraints)
+        self.addConstraint(leftPaddingConstraint!)
         self.addConstraints(vConstraintsForIconImageView)
         self.addConstraints(vConstraintsForMessageLabel)
         self.addConstraints(vConstraintsForSeperateView)


### PR DESCRIPTION
 icon/label).

![img_0012](https://cloud.githubusercontent.com/assets/2235208/18264912/34b03e04-7413-11e6-8da2-11822b22fd1c.PNG)

When setting the left margin to 0 I found that the left padding was too low. So i decided to do this enhancement.

It works by adding a new constraint that can be altered. The 2 pixel distance of iconImageView will be removed because of the 500 priority, when the left padding is set to a different value.

The default left padding is still 2, so nothing changes for anybody except someone alters the left padding.