### PR TITLE
Add identifier for UI testing

### DIFF
--- a/TTGSnackbar.podspec
+++ b/TTGSnackbar.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "TTGSnackbar"
   s.module_name  = "TTGSnackbar"
-  s.version      = "1.7.2"
+  s.version      = "1.7.3"
   s.summary      = "A Swift based implementation of the Android Snackbar for iOS. Show simple message and action button or custom view like a Toast."
 
   s.description  = <<-DESC

--- a/TTGSnackbar/TTGSnackbar.swift
+++ b/TTGSnackbar/TTGSnackbar.swift
@@ -782,6 +782,7 @@ private extension TTGSnackbar {
         contentView.addSubview(iconImageView)
 
         messageLabel = UILabel()
+        messageLabel.accessibilityIdentifier = "messageLabel"
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
         messageLabel.textColor = UIColor.white
         messageLabel.font = messageTextFont
@@ -793,6 +794,7 @@ private extension TTGSnackbar {
         contentView.addSubview(messageLabel)
 
         actionButton = UIButton()
+        actionButton.accessibilityIdentifier = "actionButton"
         actionButton.translatesAutoresizingMaskIntoConstraints = false
         actionButton.backgroundColor = UIColor.clear
         actionButton.contentEdgeInsets = UIEdgeInsetsMake(0, 4, 0, 4)
@@ -805,6 +807,7 @@ private extension TTGSnackbar {
         contentView.addSubview(actionButton)
 
         secondActionButton = UIButton()
+        secondActionButton.accessibilityIdentifier = "secondActionButton"
         secondActionButton.translatesAutoresizingMaskIntoConstraints = false
         secondActionButton.backgroundColor = UIColor.clear
         secondActionButton.contentEdgeInsets = UIEdgeInsetsMake(0, 4, 0, 4)


### PR DESCRIPTION
Right now there is no way to find the views on the snackbar unless you use your custom view. 

Added the accessibility so things can be found and used on UI test like this:

`let actionButton = app.buttons["actionButton"]
`