### PR TITLE
Revert "Typo fix and configure on init()"

### DIFF
--- a/TTGSnackbar/TTGSnackbar.swift
+++ b/TTGSnackbar/TTGSnackbar.swift
@@ -59,13 +59,7 @@ open class TTGSnackbar: UIView {
     public static var snackbarMinHeight: CGFloat = 44
     
     /// Snackbar icon imageView default width
-    @objc open dynamic var snackbarIconImageViewWidth: CGFloat = 32 {
-        didSet {
-            snackbarIconImageViewWidth = snackbarIconImageViewWidth < 32 ? 32 : snackbarIconImageViewWidth
-            iconImageViewWidthConstraint?.constant = iconImageView.isHidden ? 0 : snackbarIconImageViewWidth
-            layoutIfNeeded()
-        }
-    }
+    public static var snackbarIconImageViewWidth: CGFloat = 32
     
     // MARK: - Typealias.
     
@@ -512,7 +506,7 @@ public extension TTGSnackbar {
         
         separateView.isHidden = actionButton.isHidden
         
-        iconImageViewWidthConstraint?.constant = iconImageView.isHidden ? 0 : snackbarIconImageViewWidth
+        iconImageViewWidthConstraint?.constant = iconImageView.isHidden ? 0 : TTGSnackbar.snackbarIconImageViewWidth
         actionButtonMaxWidthConstraint?.constant = actionButton.isHidden ? 0 : actionMaxWidth
         secondActionButtonMaxWidthConstraint?.constant = secondActionButton.isHidden ? 0 : actionMaxWidth
         
@@ -807,9 +801,6 @@ private extension TTGSnackbar {
         layer.shouldRasterize = true
         layer.rasterizationScale = UIScreen.main.scale
         
-        layer.borderColor = borderColor?.cgColor
-        layer.masksToBounds = true
-        layer.borderWidth = borderWidth
         layer.shadowOpacity = 0.4
         layer.shadowRadius = 2
         layer.shadowColor = UIColor.black.cgColor
@@ -824,9 +815,8 @@ private extension TTGSnackbar {
         let iconImageView = UIImageView()
         self.iconImageView = iconImageView
         iconImageView.translatesAutoresizingMaskIntoConstraints = false
-        iconImageView.backgroundColor = iconBackgroundColor
+        iconImageView.backgroundColor = UIColor.clear
         iconImageView.contentMode = iconContentMode
-        iconImageView.tintColor = iconTint
         contentView.addSubview(iconImageView)
         
         let messageLabel = UILabel()
@@ -921,7 +911,7 @@ private extension TTGSnackbar {
         
         iconImageViewWidthConstraint = NSLayoutConstraint.init(
             item: iconImageView, attribute: .width, relatedBy: .equal,
-            toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: snackbarIconImageViewWidth)
+            toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: TTGSnackbar.snackbarIconImageViewWidth)
         
         actionButtonMaxWidthConstraint = NSLayoutConstraint.init(
             item: actionButton, attribute: .width, relatedBy: .lessThanOrEqual,


### PR DESCRIPTION
Reverts zekunyan/TTGSnackbar#72

`layer.masksToBounds = true` will disable the shadow.
And complie error.