### PR TITLE
Fixed label content inset issue

### DIFF
--- a/TTGSnackbar/TTGSnackbar.swift
+++ b/TTGSnackbar/TTGSnackbar.swift
@@ -1127,18 +1127,23 @@ open class TTGSnackbarLabel: UILabel {
     
     @objc open dynamic var contentInset: UIEdgeInsets = UIEdgeInsets.init(top: 0, left: 0, bottom: 0, right: 0) {
         didSet {
-            drawText(in: self.frame)
+            invalidateIntrinsicContentSize()
         }
     }
     
+    open override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
+        let insetRect = bounds.inset(by: contentInset)
+        let textRect = super.textRect(forBounds: insetRect, limitedToNumberOfLines: numberOfLines)
+        let invertedInsets = UIEdgeInsets(
+            top: -contentInset.top,
+            left: -contentInset.left,
+            bottom: -contentInset.bottom,
+            right: -contentInset.right)
+        return textRect.inset(by: invertedInsets)
+    }
+
     override open func drawText(in rect: CGRect) {
         super.drawText(in: rect.inset(by: contentInset))
-    }
-    
-    override open var intrinsicContentSize: CGSize {
-        let size = super.intrinsicContentSize
-        return CGSize(width: size.width + contentInset.left + contentInset.right,
-                      height: size.height + contentInset.top + contentInset.bottom)
     }
     
 }


### PR DESCRIPTION
This PR has the following changes: 
- Fixed - Message text getting cut if user update label's content Inset

Before fix: 
![Screenshot 2021-03-27 at 11 43 43 AM](https://user-images.githubusercontent.com/24249823/112712140-7cfbb580-8ef3-11eb-8367-1574c21fb43c.png)

After fix: 
![Screenshot 2021-03-27 at 11 48 36 AM](https://user-images.githubusercontent.com/24249823/112712145-8553f080-8ef3-11eb-96e7-13d6cb698c2c.png)
