### PR TITLE
Fix broken ".v91" platform version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "TTGSnackbar",
-    platforms: [.iOS(.v91)],
+    platforms: [.iOS(.v9)],
     products: [
         .library(name: "TTGSnackbar", targets: ["TTGSnackbar"])
     ],


### PR DESCRIPTION
Seeing "invalidManifestFormat" or `reference to member \'v91\' cannot be resolved without a contextual type` on your CI system? Looks like a typo got pushed to the latest tag.

Should probably consider pulling this tag, or releasing a hotfix tag: https://github.com/zekunyan/TTGSnackbar/releases/tag/1.10.6

Resolves #97